### PR TITLE
Add Special Symbol Feature 

### DIFF
--- a/Interpreter/Interpreter/Grammar/CodeGrammar.g4
+++ b/Interpreter/Interpreter/Grammar/CodeGrammar.g4
@@ -82,18 +82,19 @@ assignment_statement: (IDENTIFIER ASSIGN)+ expression?;
 
 
 expression
-    : literal                                   # literalExpression
-    | IDENTIFIER                                # identifierExpression
-    | expression AND expression                 # concatExpression
-    | expression DOLLAR expression              # newlineExpression
-    | unary_operator expression                 # unaryExpression
-    | RBRACK expression RBRACK                  # bracketExpression
-    | LPAREN expression RPAREN                  # parenthesizeExpression
-    | expression exponentOp expression          # exponentExpression    
-    | expression multOp expression              # multiplicationExpression
-    | expression addOp expression               # additionExpression
-    | expression compareOp expression           # comparisonExpression
-    | expression boolOp expression              # booleanExpression 
+    : literal                               # literalExpression
+    | IDENTIFIER                            # identifierExpression
+    | LBRACK symbol RBRACK                  # specialCharExpression
+    | expression AND expression             # concatExpression
+    | expression DOLLAR expression          # newlineExpression
+    | unary_operator expression             # unaryExpression
+    | RBRACK expression RBRACK              # bracketExpression
+    | LPAREN expression RPAREN              # parenthesizeExpression
+    | expression exponentOp expression      # exponentExpression    
+    | expression multOp expression          # multiplicationExpression
+    | expression addOp expression           # additionExpression
+    | expression compareOp expression       # comparisonExpression
+    | expression boolOp expression          # booleanExpression 
     ;
 
 multOp: MULT | DIV | MOD ;
@@ -119,6 +120,13 @@ BOOLEAN: TRUE | FALSE;
 unary_operator: PLUS | MINUS;
 
 display_statement: DISPLAY':' expression AND? NEWLINE?;
+
+symbol:
+	LPAREN
+	RPAREN
+	COMMA
+	COLON
+	;
 
 IDENTIFIER: [a-zA-Z_][a-zA-Z0-9_]*;
 

--- a/Interpreter/Interpreter/Grammar/CodeGrammar.g4
+++ b/Interpreter/Interpreter/Grammar/CodeGrammar.g4
@@ -126,6 +126,21 @@ symbol:
 	RPAREN
 	COMMA
 	COLON
+    AND
+    ASSIGN
+    DIV
+    PLUS
+    MOD
+    MULT
+    MINUS
+    NEQ
+    NOT
+    OR
+    GT
+    LT
+    DOUBLEQ
+    SINGLEQ
+    DOLLAR
 	;
 
 IDENTIFIER: [a-zA-Z_][a-zA-Z0-9_]*;

--- a/Interpreter/Interpreter/Grammar/test.code
+++ b/Interpreter/Interpreter/Grammar/test.code
@@ -1,5 +1,6 @@
 ﻿BEGIN CODE
     STRING f = "Hello World"
     INT x = 1 , y = 2 , z = 3
-    DISPLAY "Hellooww" & z $ y & x $ "Success"
+    DISPLAY: "test"
+    DISPLAY: [:]
 END CODE

--- a/Interpreter/Interpreter/Grammar/test.code
+++ b/Interpreter/Interpreter/Grammar/test.code
@@ -2,5 +2,5 @@
     STRING f = "Hello World"
     INT x = 1 , y = 2 , z = 3
     DISPLAY: "test"
-    DISPLAY: [:]
+    DISPLAY: [!]
 END CODE

--- a/Interpreter/Interpreter/Visitors/CodeVisitor.cs
+++ b/Interpreter/Interpreter/Visitors/CodeVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using Antlr4.Runtime.Misc;
 using Interpreter.ArithmeticOperations;
 using Interpreter.Grammar;
+using Microsoft.Win32.SafeHandles;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.ConstrainedExecution;
@@ -185,6 +186,13 @@ namespace Interpreter.Visitors
             return $"{left}\n{right}";
         }
 
+        public override object VisitSpecialCharExpression([NotNull] CodeGrammarParser.SpecialCharExpressionContext context)
+        {
+            var exp = context.symbol().GetText();
+
+
+            return $"{exp}";
+        }
 
         public override object VisitLiteralExpression([NotNull] CodeGrammarParser.LiteralExpressionContext context)
         {


### PR DESCRIPTION
interpreter can now display symbols with the [] but [[] does not read yet

test case:

BEGIN CODE
    STRING f = "Hello World"
    INT x = 1 , y = 2 , z = 3
    DISPLAY: "test"
    DISPLAY: [!]
END CODE